### PR TITLE
Fix triangle orientation in Skellygen and Mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ animalclub.cabal
 *.prof
 *.prof.html
 *.hp
+
+testfile

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,6 @@
+stack run -- goat
+stack run -- wormbreeder
+
 ::TODO::
 -add some punnet square sorta functions to genotype
 -new test cases

--- a/csrc/animalclub.cpp
+++ b/csrc/animalclub.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdint>
+#include <fstream>
 
 #include "HsFFI.h"
 #include "animalclub.h"
@@ -20,18 +21,20 @@ void my_exit(void){
   hs_exit();
 }
 
-// just for testing, can delete
-std::string printMesh(Mesh m) {
-  std::ostringstream r;
+void printMesh(Mesh& m, std::ostream& r) {
   for(int i = 0; i < m.vertex_count/3; i++) {
     r << "v " << m.vertices[i*3 + 0] << " " << m.vertices[i*3 + 1] << " " << m.vertices[i*3 + 2] << std::endl;
   }
   for(int i = 0; i < m.face_count/3; i++) {
     r << "f " << m.faces[i*3 + 0]+1 << " " << m.faces[i*3 + 1]+1 << " " << m.faces[i*3 + 2]+1 << std::endl;
   }
-  return r.str();
 }
 
+std::string printMesh(Mesh& m) {
+  std::ostringstream r;
+  printMesh(m, r);
+  return r.str();
+}
 
 void breed(uint32_t seed, char* dna1, char* dna2, char* outdna, uint32_t size) {
   breed_hs(seed, dna1, dna2, outdna, size);
@@ -56,6 +59,12 @@ void free_goat_mesh(Mesh* ptr) {
   free_goat_mesh_hs((HsPtr)ptr);
 }
 
-void dump_goat(GoatSpecimenPtr ptr) {
-  dump_goat_hs(ptr);
+void dump_goat(GoatSpecimenPtr ptr, const char* filename) {
+  //dump_goat_hs(ptr);
+  Mesh* mesh = goat_mesh(ptr);
+  std::fstream fs;
+  fs.open (filename, std::fstream::out);
+  printMesh(*mesh, fs);
+  fs.close();
+  free_goat_mesh(mesh);
 }

--- a/csrc/animalclub.h
+++ b/csrc/animalclub.h
@@ -28,4 +28,4 @@ extern "C" void free_goat(GoatSpecimenPtr goat);
 extern "C" GoatSpecimenPtr breed_goat(GoatSpecimenPtr, GoatSpecimenPtr);
 extern "C" Mesh* goat_mesh(GoatSpecimenPtr);
 extern "C" void free_goat_mesh(Mesh*);
-extern "C" void dump_goat(GoatSpecimenPtr);
+extern "C" void dump_goat(GoatSpecimenPtr, const char*);

--- a/ctest/test_all.cpp
+++ b/ctest/test_all.cpp
@@ -28,7 +28,7 @@ bool test_breed_hs() {
 
 bool test_goat() {
   GoatSpecimenPtr gptr = random_goat();
-  dump_goat(gptr);
+  dump_goat(gptr, "testfile");
   Mesh* gmesh = goat_mesh(gptr);
   //cout << printMesh(*gmesh);
   free_goat_mesh(gmesh);

--- a/src/AnimalClub/Skellygen/Mesh.hs
+++ b/src/AnimalClub/Skellygen/Mesh.hs
@@ -92,15 +92,22 @@ potatoMeshToObj (PotatoMesh p n tc i) = execWriter $ do
     sc a = st a <> "/" <> st a <> "/" <> st a
   V.mapM_ (\(a1,a2,a3) -> tell $ "f " <> sc a1 <> " " <> sc a2 <> " " <> sc a3 <> "\n") $ i
 
+
+shuffleIndex :: Face -> Face
+shuffleIndex (x,y,z) = (x,z,y)
+
 transformPotatoMeshM44 :: (AnimalFloat a) => M44 a -> PotatoMesh a -> PotatoMesh a
 transformPotatoMeshM44 t (PotatoMesh p n tc i) = r where
-  -- transform the normal (drop translation and invert scale)
-  nt n' = signorm $ (transpose (inv33 $ conv_M44_M33_droptrans t)) !* n'
+  -- transform the normals (drop translation and invert scale)
+  t' = conv_M44_M33_droptrans t
+  nt n' = signorm $ (inv33 $ t') !* n'
+  -- shuffle tri indices to maintain correct orientation
+  it = if det33 t' > 0 then id else shuffleIndex
   r = PotatoMesh
     (V.map (mul_M44_V3 t) p)
     (V.map nt n)
     tc
-    i
+    (V.map it i)
 
 -- old LocalMesh stuff, you can delete this
 

--- a/src/AnimalClub/Skellygen/Skellygen.hs
+++ b/src/AnimalClub/Skellygen/Skellygen.hs
@@ -108,11 +108,14 @@ generateSinglePotatoMesh pos ct pt =
   end' = view translation pos
   start' = V3 0 0 0
   length' = norm (end' - start')
-  normalized = _normalize $ end' - start'
+  normalized = signorm $ end' - start'
   start = start' --  - ex *^ normalized
   end = end' -- + ey *^ normalized
 
+  -- TODO rename this variable?? Why did I call it "upAxis"???
   -- TODO upAxis should use the up direction of pos
+  -- right now all meshes are oriented the same way (edge of mesh pointing directly up)
+  -- i.e. there is no rotation component along normalized for the mesh being generated
   upAxis = rotate (fromTo (V3 0 1 0) normalized)
 
   divs = 4 :: Int
@@ -127,8 +130,8 @@ generateSinglePotatoMesh pos ct pt =
 
   allPoints = startPoints ++ endPoints
 
-  sides = [(0, 1, 4), (5, 4, 1), (1, 2, 5), (6, 5, 2), (2, 3, 6), (7, 6, 3), (3, 0, 7), (4, 7, 0)]
-  caps = [(0, 1, 3), (2, 3, 1), (6, 7, 5), (4, 5, 7)]
+  sides = [(0, 4, 1), (5, 1, 4), (1, 5, 2), (6, 2, 5), (2, 6, 3), (7, 3, 6), (3, 7, 0), (4, 0, 7)]
+  caps = [(0, 1, 3), (2, 3, 1), (6, 5, 7), (4, 7, 5)]
   allIndices = sides ++ caps
 
   -- per face normals
@@ -136,9 +139,9 @@ generateSinglePotatoMesh pos ct pt =
     mapfn a = upAxis npt where
       -- rotate a little more to get normal for face
       a' = a + pi / fromIntegral divs
-      npt = V3 (pt * cos a') 0 (pt * sin a')
-  capNormals = map upAxis [V3 0 (-1) 0, V3 0 1 0]
-  allNormals = map signorm (sideNormals ++ capNormals)
+      npt = V3 (cos a') 0 (sin a')
+  capNormals = map upAxis [V3 0 1 0, V3 0 (-1) 0]
+  allNormals = (sideNormals ++ capNormals)
 
   -- rendy requires same buffer indices for position, normal and tex coords
   -- therefore we reindex everything and duplicate positions/normals


### PR DESCRIPTION
triangle indexing needs to be shuffled when there is a reflection in the transform matrix